### PR TITLE
Adding a Vagrantfile for spinning up a development VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,8 +50,9 @@ Vagrant.configure("2") do |config|
   # backing providers for Vagrant. These expose provider-specific options.
   # Example for VirtualBox:
   #
-  # config.vm.provider "virtualbox" do |vb|
-  #   vb.memory = "1024"
+   config.vm.provider "virtualbox" do |vb|
+     vb.memory = "1024"
+	end
   #   # Display the VirtualBox GUI when booting the machine
   #   vb.gui = true
   #


### PR DESCRIPTION
Vagrant is a tool for using virtual machines to share development environments.
Learn more about it at:
https://www.vagrantup.com/
Also making changes to the `.gitignore` file to ignore so data that Vagrant
creates.